### PR TITLE
More unit test, plus internal naming switch

### DIFF
--- a/lib/src/main/java/com/sanuscorp/transbeamer/AvroFormat.java
+++ b/lib/src/main/java/com/sanuscorp/transbeamer/AvroFormat.java
@@ -44,7 +44,7 @@ public final class AvroFormat implements FileFormat {
     @Override
     public <
         T extends GenericRecord
-    > FileIO.Sink<T> getWriter(final Class<T> clazz) {
+    > FileIO.Sink<T> getSink(final Class<T> clazz) {
         return AvroIO.sink(clazz);
     }
 }

--- a/lib/src/main/java/com/sanuscorp/transbeamer/CsvFormat.java
+++ b/lib/src/main/java/com/sanuscorp/transbeamer/CsvFormat.java
@@ -42,7 +42,7 @@ public final class CsvFormat implements FileFormat {
     }
 
     @Override
-    public <T extends GenericRecord> FileIO.Sink<T> getWriter(
+    public <T extends GenericRecord> FileIO.Sink<T> getSink(
         final Class<T> clazz
     ) {
         return OpenCsvSink.of(clazz);

--- a/lib/src/main/java/com/sanuscorp/transbeamer/DataWriter.java
+++ b/lib/src/main/java/com/sanuscorp/transbeamer/DataWriter.java
@@ -52,7 +52,7 @@ public final class DataWriter<T extends GenericRecord> extends PTransform<
             writer = writer.withNumShards(this.numShards);
         }
 
-        final FileIO.Sink<T> sink = format.getWriter(clazz);
+        final FileIO.Sink<T> sink = format.getSink(clazz);
 
         LOG.debug("Writing {} instances to {}/{}*{}",
             clazz.getSimpleName(),

--- a/lib/src/main/java/com/sanuscorp/transbeamer/FileFormat.java
+++ b/lib/src/main/java/com/sanuscorp/transbeamer/FileFormat.java
@@ -46,7 +46,7 @@ public interface FileFormat {
      * @return The writer
      * @param <T> The Avro-generated class this format will write from.
      */
-    <T extends GenericRecord> FileIO.Sink<T> getWriter(
+    <T extends GenericRecord> FileIO.Sink<T> getSink(
         Class<T> clazz
     );
 }

--- a/lib/src/main/java/com/sanuscorp/transbeamer/NDJsonFormat.java
+++ b/lib/src/main/java/com/sanuscorp/transbeamer/NDJsonFormat.java
@@ -41,9 +41,9 @@ public final class NDJsonFormat implements FileFormat {
     }
 
     @Override
-    public <T extends GenericRecord> FileIO.Sink<T> getWriter(
+    public <T extends GenericRecord> FileIO.Sink<T> getSink(
         final Class<T> clazz
     ) {
-        return NDJsonWriter.of(clazz);
+        return NDJsonSink.of(clazz);
     }
 }

--- a/lib/src/main/java/com/sanuscorp/transbeamer/NDJsonReaderFn.java
+++ b/lib/src/main/java/com/sanuscorp/transbeamer/NDJsonReaderFn.java
@@ -21,7 +21,7 @@ public final class NDJsonReaderFn<T> extends DoFn<
 
     private transient Gson gson;
 
-    private NDJsonReaderFn(final Class<T> clazz) {
+    NDJsonReaderFn(final Class<T> clazz) {
         this.clazz = clazz;
     }
 

--- a/lib/src/main/java/com/sanuscorp/transbeamer/NDJsonSink.java
+++ b/lib/src/main/java/com/sanuscorp/transbeamer/NDJsonSink.java
@@ -3,6 +3,7 @@ package com.sanuscorp.transbeamer;
 import com.google.gson.FormattingStyle;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.Strictness;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.io.FileIO;
 
@@ -19,7 +20,7 @@ import java.nio.charset.StandardCharsets;
  * how to write Newline-Delimited JSON files.
  * @param <T> The type that will be written out as ND-JSON.
  */
-public class NDJsonWriter<T extends GenericRecord> implements FileIO.Sink<T> {
+public class NDJsonSink<T extends GenericRecord> implements FileIO.Sink<T> {
 
     private final Class<T> clazz;
 
@@ -27,19 +28,20 @@ public class NDJsonWriter<T extends GenericRecord> implements FileIO.Sink<T> {
 
     private BufferedWriter bufferedWriter;
 
-    public NDJsonWriter(final Class<T> clazz) {
+    public NDJsonSink(final Class<T> clazz) {
         this.clazz = clazz;
     }
 
-    public static <T extends GenericRecord> NDJsonWriter<T> of(
+    public static <T extends GenericRecord> NDJsonSink<T> of(
         final Class<T> clazz
     ) {
-        return new NDJsonWriter<>(clazz);
+        return new NDJsonSink<>(clazz);
     }
 
     @Override
     public void open(final WritableByteChannel channel) {
         gson = new GsonBuilder()
+            .setStrictness(Strictness.STRICT)
             .setFormattingStyle(FormattingStyle.COMPACT)
             .create();
 
@@ -56,7 +58,7 @@ public class NDJsonWriter<T extends GenericRecord> implements FileIO.Sink<T> {
     @Override
     public void write(final T element) throws IOException {
         gson.toJson(element, clazz, bufferedWriter);
-        bufferedWriter.write("\n");
+        bufferedWriter.write(System.lineSeparator());
     }
 
     @Override

--- a/lib/src/main/java/com/sanuscorp/transbeamer/ParquetFormat.java
+++ b/lib/src/main/java/com/sanuscorp/transbeamer/ParquetFormat.java
@@ -44,7 +44,7 @@ public final class ParquetFormat implements FileFormat {
     }
 
     @Override
-    public <T extends GenericRecord> FileIO.Sink<T> getWriter(
+    public <T extends GenericRecord> FileIO.Sink<T> getSink(
         final Class<T> clazz
     ) {
         return ParquetSink.of(clazz);

--- a/lib/src/test/java/com/sanuscorp/transbeamer/AvroFormatTests.java
+++ b/lib/src/test/java/com/sanuscorp/transbeamer/AvroFormatTests.java
@@ -82,7 +82,7 @@ public class AvroFormatTests {
             mockedAvroIO.when(() -> AvroIO.sink(Person.class))
                 .thenReturn(avroIOSink);
 
-            result = AvroFormat.create().getWriter(Person.class);
+            result = AvroFormat.create().getSink(Person.class);
         }
 
         @Test

--- a/lib/src/test/java/com/sanuscorp/transbeamer/CsvFormatTests.java
+++ b/lib/src/test/java/com/sanuscorp/transbeamer/CsvFormatTests.java
@@ -99,7 +99,7 @@ public class CsvFormatTests {
             mockedOpenCsvSink.when(() -> OpenCsvSink.of(any()))
                 .thenReturn(openCsvSink);
 
-            result = CsvFormat.create().getWriter(Person.class);
+            result = CsvFormat.create().getSink(Person.class);
         }
 
         @Test

--- a/lib/src/test/java/com/sanuscorp/transbeamer/DataWriterTests.java
+++ b/lib/src/test/java/com/sanuscorp/transbeamer/DataWriterTests.java
@@ -71,7 +71,7 @@ class DataWriterTests {
 
         mockedFileIO.when(FileIO::write).thenReturn(fileIOWrite);
 
-        when(format.getWriter(any())).thenAnswer(invocation -> fileIOSink);
+        when(format.getSink(any())).thenAnswer(invocation -> fileIOSink);
 
         when(people.getPipeline()).thenReturn(pipeline);
 
@@ -115,7 +115,7 @@ class DataWriterTests {
 
     @Test
     void it_creates_one_FileIO_sink() {
-        verify(format).getWriter(CLASS);
+        verify(format).getSink(CLASS);
     }
 
     @Test

--- a/lib/src/test/java/com/sanuscorp/transbeamer/NDJsonFormatTests.java
+++ b/lib/src/test/java/com/sanuscorp/transbeamer/NDJsonFormatTests.java
@@ -1,0 +1,120 @@
+package com.sanuscorp.transbeamer;
+
+import com.sanuscorp.transbeamer.test.avro.Person;
+import org.apache.beam.sdk.io.FileIO;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
+/**
+ * Unit tests for the NDJsonFormat class.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("The NDJsonFormat Class")
+public class NDJsonFormatTests {
+
+    // Fixtures
+    private static final String FILE_PATTERN = "fake/pattern";
+
+    // Dependencies
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private MockedStatic<NDJsonReader> mockedNDJsonReader;
+
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private MockedStatic<NDJsonSink> mockedNDJsonWriter;
+
+    // Interim values
+    @Mock
+    private NDJsonReader<Person> ndJsonReader;
+
+    @Mock
+    private NDJsonSink<Person> ndJsonSink;
+
+    @Nested
+    class when_created {
+
+        private NDJsonFormat result;
+
+        @BeforeEach
+        void beforeEach() {
+            result = NDJsonFormat.create();
+        }
+
+        @Test
+        void it_returns_the_expected_name() {
+            assertThat(result.getName()).isEqualTo("ND-JSON");
+        }
+
+        @Test
+        void it_returns_the_expected_suffix() {
+            assertThat(result.getSuffix()).isEqualTo("ndjson");
+        }
+
+    }
+
+    @Nested
+    class when_getting_a_reader {
+
+        private PTransform<
+            @NonNull PBegin,
+            @NonNull PCollection<Person>
+            > result;
+
+        @BeforeEach
+        void beforeEach() {
+            mockedNDJsonReader.when(() -> NDJsonReader.read(anyString(), any()))
+                .thenReturn(ndJsonReader);
+
+            result = NDJsonFormat.create().getReader(FILE_PATTERN, Person.class);
+        }
+
+        @Test
+        void getting_the_reader_creates_one_reader() {
+            mockedNDJsonReader.verify(() -> NDJsonReader.read(anyString(), any()));
+        }
+
+        @Test
+        void it_returns_the_expected_reader() {
+            assertThat(result).isEqualTo(ndJsonReader);
+        }
+    }
+
+    @Nested
+    class when_getting_a_writer {
+
+        private FileIO.Sink<Person> result;
+
+        @BeforeEach
+        void beforeEach() {
+            mockedNDJsonWriter.when(() -> NDJsonSink.of(any()))
+                .thenReturn(ndJsonSink);
+
+            result = NDJsonFormat.create().getSink(Person.class);
+        }
+
+        @Test
+        void getting_the_writer_creates_one_writer() {
+            mockedNDJsonWriter.verify(() -> NDJsonSink.of(Person.class));
+        }
+
+        @Test
+        void it_returns_the_expected_writer() {
+            assertThat(result).isEqualTo(ndJsonSink);
+        }
+    }
+}

--- a/lib/src/test/java/com/sanuscorp/transbeamer/NDJsonReaderFnTests.java
+++ b/lib/src/test/java/com/sanuscorp/transbeamer/NDJsonReaderFnTests.java
@@ -1,0 +1,86 @@
+package com.sanuscorp.transbeamer;
+
+import com.sanuscorp.transbeamer.test.avro.Person;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+/**
+ * JUnit tests for the {@link NDJsonReaderFn} class.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("The NDJsonReaderFn class")
+public class NDJsonReaderFnTests {
+
+    // Fixtures
+    private static final String TEST_ELEMENT =
+        "{\"firstName\":\"John\",\"lastName\":\"Doe\",\"age\":30}";
+
+    private static final Person EXPECTED_PERSON = Person.newBuilder()
+        .setFirstName("John")
+        .setLastName("Doe")
+        .setAge(30)
+        .build();
+
+    @Nested
+    class when_creating_a_par_do {
+
+        // Dependencies
+        @Mock
+        private MockedStatic<ParDo> mockedParDo;
+
+        // Interim values
+        @Mock
+        private ParDo.SingleOutput<String, Person> parDoSingleOutput;
+
+        private ParDo.SingleOutput<String, Person> result;
+
+        @BeforeEach
+        void beforeEach() {
+            mockedParDo.when(() -> ParDo.of(any()))
+                .thenReturn(parDoSingleOutput);
+
+            result = NDJsonReaderFn.parDoOf(Person.class);
+        }
+
+        @Test
+        void it_creates_a_single_par_do() {
+            mockedParDo.verify(() -> ParDo.of(any()));
+        }
+
+        @Test
+        void it_returns_the_expected_result() {
+            assertThat(result).isEqualTo(parDoSingleOutput);
+        }
+    }
+
+    @Nested
+    class when_processing_an_element {
+
+        // Inputs
+        @Mock
+        private DoFn.OutputReceiver<Person> outputReceiver;
+
+        @BeforeEach
+        void beforeEach() {
+            final NDJsonReaderFn<Person> readerFn = new NDJsonReaderFn<>(Person.class);
+            readerFn.processElement(TEST_ELEMENT, outputReceiver);
+        }
+
+        @Test
+        void it_outputs_one_Person_element() {
+            verify(outputReceiver).output(EXPECTED_PERSON);
+        }
+    }
+}

--- a/lib/src/test/java/com/sanuscorp/transbeamer/NDJsonReaderTests.java
+++ b/lib/src/test/java/com/sanuscorp/transbeamer/NDJsonReaderTests.java
@@ -1,0 +1,127 @@
+package com.sanuscorp.transbeamer;
+
+import com.sanuscorp.transbeamer.test.avro.Person;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link NDJsonReader} class.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("The NDJsonReader Class")
+public class NDJsonReaderTests {
+
+    // Fixtures
+    private static final String FILE_PATTERN = "input/location";
+
+    // Inputs
+    @Mock
+    private PBegin pBegin;
+
+    // Dependencies
+    @Mock
+    private MockedStatic<TextIO> mockedTextIO;
+
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private MockedStatic<NDJsonReaderFn> mockedNDJsonReaderFn;
+
+    // Interim results
+    @Mock
+    private Pipeline pipeline;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private TextIO.Read textIORead;
+
+    @Mock
+    private PCollection<String> lines;
+
+    @Mock
+    private ParDo.SingleOutput<String, Person> ndJsonReaderParDo;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private PCollection<Person> people;
+
+    @Nested
+    class when_expanding_a_reader {
+
+        private PCollection<Person> result;
+
+        @BeforeEach
+        void beforeEach() {
+            when(pBegin.getPipeline()).thenReturn(pipeline);
+            mockedTextIO.when(TextIO::read).thenReturn(textIORead);
+            when(pipeline.apply(anyString(), any())).thenReturn(lines);
+
+            mockedNDJsonReaderFn.when(
+                () -> NDJsonReaderFn.parDoOf(any())
+            ).thenReturn(ndJsonReaderParDo);
+
+            when(lines.apply(anyString(), any())).thenReturn(people);
+
+            result = NDJsonReader
+                .read(FILE_PATTERN, Person.class)
+                .expand(pBegin);
+        }
+
+        @Test
+        void it_gets_the_pipeline_from_the_input() {
+            verify(pBegin).getPipeline();
+        }
+
+        @Test
+        void it_creates_one_TextIO_read() {
+            mockedTextIO.verify(TextIO::read);
+        }
+
+        @Test
+        void it_reads_from_the_given_file_pattern() {
+            verify(textIORead).from(FILE_PATTERN);
+        }
+
+        @Test
+        void it_applies_the_TextIO_Read_to_the_pipeline() {
+            verify(pipeline).apply(anyString(), eq(textIORead));
+        }
+
+        @Test
+        void it_creates_one_NDJsonReaderFn_pardo() {
+            mockedNDJsonReaderFn.verify(
+                () -> NDJsonReaderFn.parDoOf(Person.class)
+            );
+        }
+
+        @Test
+        void it_applies_the_NDJsonReaderFn_pardo_to_the_lines() {
+            verify(lines).apply(anyString(), eq(ndJsonReaderParDo));
+        }
+
+        @Test
+        void it_sets_the_coder_on_the_collection() {
+            verify(people).setCoder(AvroCoder.of(Person.class));
+        }
+
+        @Test
+        void it_returns_the_expected_collection() {
+            assertThat(result).isEqualTo(people);
+        }
+    }
+}

--- a/lib/src/test/java/com/sanuscorp/transbeamer/NDJsonSinkTests.java
+++ b/lib/src/test/java/com/sanuscorp/transbeamer/NDJsonSinkTests.java
@@ -1,0 +1,229 @@
+package com.sanuscorp.transbeamer;
+
+import com.google.gson.FormattingStyle;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.sanuscorp.transbeamer.test.avro.Person;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for the {@link NDJsonSink} class.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("The NDJsonSink Class")
+public class NDJsonSinkTests {
+
+    // Dependencies
+    private MockedConstruction<GsonBuilder> mockedGsonBuilderConstruction;
+
+    @Mock
+    private MockedStatic<Channels> mockedChannels;
+
+    private MockedConstruction<
+        OutputStreamWriter
+    > mockedOutputStreamWriterConstruction;
+
+    private List<Object> writerConstructorArgs;
+
+    private MockedConstruction<BufferedWriter> mockedBufferedWriterConstruction;
+
+    private List<Object> bufferedWriterConstructorArgs;
+
+    // Inputs
+    @Mock
+    private WritableByteChannel channel;
+
+    // Interim Values
+    @Mock(answer = Answers.RETURNS_SELF)
+    private GsonBuilder gsonBuilder;
+
+    @Mock
+    private Gson gson;
+
+    private OutputStreamWriter writer;
+
+    private BufferedWriter bufferedWriter;
+
+    @Mock
+    private OutputStream stream;
+
+    private void mockOpen() {
+        mockedGsonBuilderConstruction = mockConstructionWithAnswer(
+            GsonBuilder.class,
+            invocation -> gsonBuilder
+        );
+        when(gsonBuilder.create()).thenReturn(gson);
+
+        mockedOutputStreamWriterConstruction = mockConstruction(
+            OutputStreamWriter.class,
+            (mock, context) -> {
+                writerConstructorArgs = new ArrayList<>(context.arguments());
+                writer = mock;
+            }
+        );
+        mockedBufferedWriterConstruction = mockConstruction(
+            BufferedWriter.class,
+            (mock, context) -> {
+                bufferedWriterConstructorArgs = new ArrayList<>(
+                    context.arguments()
+                );
+                bufferedWriter = mock;
+            }
+        );
+
+        mockedChannels.when(
+            () -> Channels.newOutputStream(any(WritableByteChannel.class))
+        ).thenReturn(stream);
+    }
+
+    private void afterMockOpen() {
+        mockedGsonBuilderConstruction.close();
+        mockedOutputStreamWriterConstruction.close();
+        mockedBufferedWriterConstruction.close();
+    }
+
+    @Nested
+    class when_opening_a_channel {
+
+        @BeforeEach
+        void beforeEach() {
+            mockOpen();
+
+            final NDJsonSink<Person> writer = NDJsonSink.of(Person.class);
+            writer.open(channel);
+        }
+
+        @AfterEach
+        void afterEach() {
+            afterMockOpen();
+        }
+
+        @Test
+        void it_creates_one_GsonBuilder() {
+            assertThat(mockedGsonBuilderConstruction.constructed()).hasSize(1);
+        }
+
+        @Test
+        void it_sets_the_formatting_style_to_compact() {
+            verify(gsonBuilder).setFormattingStyle(FormattingStyle.COMPACT);
+        }
+
+        @Test
+        void it_creates_the_gson_instance() {
+            verify(gsonBuilder).create();
+        }
+
+        @Test
+        void it_creates_one_OutputStream_from_the_channel() {
+            mockedChannels.verify(() -> Channels.newOutputStream(channel));
+        }
+
+        @Test
+        void it_creates_one_OutputStreamWriter() {
+            assertThat(mockedOutputStreamWriterConstruction.constructed()).hasSize(1);
+        }
+
+        @Test
+        void it_uses_the_stream_and_UTF_8_as_the_constructor_arguments() {
+            assertThat(writerConstructorArgs).containsExactly(
+                stream,
+                StandardCharsets.UTF_8
+            );
+        }
+
+        @Test
+        void it_creates_one_BufferedWriter() {
+            assertThat(mockedBufferedWriterConstruction.constructed()).hasSize(1);
+        }
+
+        @Test
+        void it_uses_the_writer_as_the_BufferedWriter_constructor_argument() {
+            assertThat(bufferedWriterConstructorArgs).containsExactly(writer);
+        }
+    }
+
+    @Nested
+    class when_opening_and_writing_an_element {
+
+        // Inputs
+        @Mock
+        private Person person;
+
+        @BeforeEach
+        void beforeEach() throws IOException {
+            mockOpen();
+
+            final NDJsonSink<Person> writer = NDJsonSink.of(Person.class);
+            writer.open(channel);
+            writer.write(person);
+        }
+
+        @AfterEach
+        void afterEach() {
+            afterMockOpen();
+        }
+
+        @Test
+        void it_uses_gson_to_write_the_element() {
+            verify(gson).toJson(person, Person.class, bufferedWriter);
+        }
+
+        @Test
+        void it_writes_a_newline_after_writing_the_element() throws IOException {
+            verify(bufferedWriter).write(System.lineSeparator());
+        }
+    }
+
+    @Nested
+    class when_opening_and_flushing_the_writer {
+
+        @BeforeEach
+        void beforeEach() throws IOException {
+            mockOpen();
+            final NDJsonSink<Person> writer = NDJsonSink.of(Person.class);
+            writer.open(channel);
+            writer.flush();
+        }
+
+        @AfterEach
+        void afterEach() {
+            afterMockOpen();
+        }
+
+        @Test
+        void it_flushes_the_buffered_writer() throws IOException {
+            verify(bufferedWriter).flush();
+        }
+
+        @Test
+        void it_closes_the_buffered_writer() throws IOException {
+            verify(bufferedWriter).close();
+        }
+    }
+
+    @Nested
+    class when_flushing_before_opening {
+        @Test
+        void it_does_not_error() throws IOException {
+            final NDJsonSink<Person> writer = NDJsonSink.of(Person.class);
+            writer.flush();
+        }
+    }
+}


### PR DESCRIPTION
This adds unit test for the NDJson* files, as well as tweaks the naming
of the output portion to be "Sink" instead of "Writer".  That's more
consistent across the codebase at this point.
