### PR TITLE
feat: Add GCP Pubsub as a supported Format

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.configuration-cache=false
 GITHUB_ORG=sanuscorp
 LIBRARY_GROUP=com.sanuscorp
 LIBRARY_NAME=transbeamer
-LIBRARY_VERSION=2.0.0
+LIBRARY_VERSION=2.1.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ beam-core = { module = "org.apache.beam:beam-sdks-java-core", version.ref = "apa
 beam-avro = { module = "org.apache.beam:beam-sdks-java-extensions-avro", version.ref = "apache-beam" }
 beam-direct-runner = { module = "org.apache.beam:beam-runners-direct-java", version.ref = "apache-beam" }
 beam-parquet = { module = "org.apache.beam:beam-sdks-java-io-parquet", version.ref = "apache-beam" }
+beam-gcs = { module = "org.apache.beam:beam-sdks-java-io-google-cloud-platform", version.ref = "apache-beam" }
 beam-aws-sdk = { module = "org.apache.beam:beam-sdks-java-io-amazon-web-services2", version.ref = "apache-beam" }
 beam-aws-kinesis = { module = "com.amazonaws:aws-kinesisanalytics-runtime", version = "1.2.0" }
 beam-flink-runner = { module = "org.apache.beam:beam-runners-flink-1.19", version.ref = "apache-beam" }
@@ -55,7 +56,7 @@ avro = { id = "com.github.davidmc24.gradle.plugin.avro", version.ref = "avro-plu
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow-plugin"}
 
 [bundles]
-beam = ["beam-core", "beam-avro", "beam-direct-runner", "beam-parquet", "beam-aws-sdk", "beam-flink-runner"]
+beam = ["beam-core", "beam-avro", "beam-direct-runner", "beam-parquet", "beam-aws-sdk", "beam-flink-runner", "beam-gcs"]
 hadoop = ["hadoop-common", "hadoop-mapreduce"]
 log4j = ["log4j-api", "log4j-core"]
 testing = ["junit-api", "junit-engine", "junit-params", "mockito-core", "mockito-junit", "assertj"]

--- a/lib/src/main/java/com/sanuscorp/transbeamer/DataFormat.java
+++ b/lib/src/main/java/com/sanuscorp/transbeamer/DataFormat.java
@@ -2,35 +2,27 @@ package com.sanuscorp.transbeamer;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.specific.SpecificRecordBase;
-import org.apache.beam.sdk.io.FileIO;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
- * This interface defines the type that enables reading and writing of data
- * files in a variety of formats.
+ * This interface defines a type that enables reading and writing of data
+ * sources and sinks.
  */
-public interface FileFormat {
+public interface DataFormat {
 
     /**
-     * The name of the file format.
-     * @return The name
+     * Get the name of the data format.  This is likely only useful for logging.
+     * @return The name of the format.
      */
     String getName();
 
     /**
-     * The suffix of the data file to write, if any.
-     * @return The suffix.
-     */
-    String getSuffix();
-
-    /**
      * Get a data reader for this format.  Some data formats will build
      * new transforms, while others may delegate to Beam IO classes.
-     * @param dataPattern The pattern of the data to read.  This may be a
-     * glob-like string.
      * @param clazz The Avro-generated class to populate
      * @return The reader
      * @param <T> The Avro-generated class that will store elements consumed.
@@ -38,15 +30,19 @@ public interface FileFormat {
     <T extends SpecificRecordBase> PTransform<
         @NonNull PBegin,
         @NonNull PCollection<T>
-    > getReader(String dataPattern, Class<T> clazz);
+    > getReader(Class<T> clazz);
+
 
     /**
-     * Get a data writer for this format.
-     * @param clazz The Avro-generated class this format will write from.
-     * @return The writer
-     * @param <T> The Avro-generated class this format will write from.
+     * Get a data reader for this format.  Some data formats will build
+     * new transforms, while others may delegate to Beam IO classes.
+     * @param clazz The Avro-generated class to populate
+     * @return The reader
+     * @param <T> The Avro-generated class that will store elements consumed.
      */
-    <T extends GenericRecord> FileIO.Sink<T> getSink(
-        Class<T> clazz
-    );
+    <T extends GenericRecord> PTransform<
+        @NonNull PCollection<T>,
+        @NonNull PDone
+    > getWriter(Class<T> clazz);
+
 }

--- a/lib/src/main/java/com/sanuscorp/transbeamer/DataReader.java
+++ b/lib/src/main/java/com/sanuscorp/transbeamer/DataReader.java
@@ -1,0 +1,46 @@
+package com.sanuscorp.transbeamer;
+
+import org.apache.avro.specific.SpecificRecordBase;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * This class provides the format-agnostic Reader transform.
+ * @param <T> The element type that this transform will read into.
+ */
+public final class DataReader<T extends SpecificRecordBase> extends PTransform<
+    @NonNull PBegin,
+    @NonNull PCollection<T>
+> {
+    private static final Logger LOG = LogManager.getLogger(DataReader.class);
+
+    private final DataFormat format;
+
+    private final Class<T> clazz;
+
+    DataReader(final DataFormat format, final Class<T> clazz) {
+        this.format = format;
+        this.clazz = clazz;
+    }
+
+    @Override
+    public @NonNull PCollection<T> expand(@NonNull final PBegin input) {
+        LOG.debug(
+            "Reading data from {} into {}",
+            format.getName(),
+            clazz.getSimpleName()
+        );
+
+        final PTransform<@NonNull PBegin, @NonNull PCollection<T>> reader =
+            format.getReader(clazz);
+
+        return input.apply(
+            "Read from " + format.getName(),
+            reader
+        );
+    }
+}

--- a/lib/src/main/java/com/sanuscorp/transbeamer/DataWriter.java
+++ b/lib/src/main/java/com/sanuscorp/transbeamer/DataWriter.java
@@ -1,0 +1,46 @@
+package com.sanuscorp.transbeamer;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * This class knows how to write data described in {@link DataFormat} types.
+ * @param <T> The Avro type backing the {@link PCollection} holding the data to
+ * be written.
+ */
+public class DataWriter<T extends GenericRecord> extends PTransform<
+    @NonNull PCollection<T>,
+    @NonNull PDone
+> {
+    private static final Logger LOG = LogManager.getLogger(DataWriter.class);
+
+    private final DataFormat format;
+
+    private final Class<T> clazz;
+
+    DataWriter(final DataFormat format, final Class<T> clazz) {
+        this.format = format;
+        this.clazz = clazz;
+    }
+
+    @Override
+    public @NonNull PDone expand(@NonNull final PCollection<T> input) {
+        LOG.debug(
+            "Writing {} instances to {}",
+            clazz.getSimpleName(),
+            format.getName()
+        );
+
+        final PTransform<
+            @NonNull PCollection<T>,
+            @NonNull PDone
+        > writer = format.getWriter(clazz);
+
+        return input.apply("Write to " + format.getName(), writer);
+    }
+}

--- a/lib/src/main/java/com/sanuscorp/transbeamer/PubsubFormat.java
+++ b/lib/src/main/java/com/sanuscorp/transbeamer/PubsubFormat.java
@@ -1,0 +1,113 @@
+package com.sanuscorp.transbeamer;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.specific.SpecificRecordBase;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * This format defines how to read and write to Google Cloud's PubSub topics.
+ */
+public final class PubsubFormat implements DataFormat {
+
+    private @Nullable String topic;
+
+    private @Nullable String subscription;
+
+    private PubsubFormat() {
+        // Intentionally empty
+    }
+
+    /**
+     * Create a {@link DataFormat} instance with a given Pubsub topic.  The
+     * format will be suitable for both reading and writing messages.
+     * @param topic The topic to read or write to
+     * @return The created data format.
+     */
+    public static PubsubFormat withTopic(final String topic) {
+        final PubsubFormat format = new PubsubFormat();
+        format.topic = topic;
+        return format;
+    }
+
+    /**
+     * Create a {@link DataFormat} instance with a given Pubsub topic provider.
+     * The format will be suitable for both reading and writing messages.
+     * @param topicProvider The provider that names the topic.
+     * @return The created data format.
+     */
+    public static PubsubFormat withTopic(
+        final ValueProvider<String> topicProvider
+    ) {
+        final PubsubFormat format = new PubsubFormat();
+        format.topic = topicProvider.get();
+        return format;
+    }
+
+    /**
+     * Create a {@link DataFormat} instance configured to read from the given
+     * GCP Pubsub subscription.  The created format will only be suitable for
+     * reading.
+     * @param subscription The subscription to read from.
+     * @return The created data format.
+     */
+    public static PubsubFormat withSubscription(final String subscription) {
+        final PubsubFormat format = new PubsubFormat();
+        format.subscription = subscription;
+        return format;
+    }
+
+    /**
+     * Create a {@link DataFormat} instance configured to read from the provided
+     * GCP Pubsub Subscription.  The created format will only be suitable for
+     * reading.
+     * @param subscriptionProvider The provider that will specify the
+     * subscription.
+     * @return The created data format.
+     */
+    public static PubsubFormat withSubscription(
+        final ValueProvider<String> subscriptionProvider
+    ) {
+        final PubsubFormat format = new PubsubFormat();
+        format.subscription = subscriptionProvider.get();
+        return format;
+    }
+
+    @Override
+    public String getName() {
+        return "GCP Pubsub Topic: " + topic;
+    }
+
+    @Override
+    public <T extends SpecificRecordBase> PTransform<
+        @NonNull PBegin,
+        @NonNull PCollection<T>
+    > getReader(final Class<T> clazz) {
+        final PubsubIO.Read<T> avroReader = PubsubIO.readAvros(clazz);
+        if (subscription != null) {
+            return avroReader.fromSubscription(subscription);
+        }
+
+        return avroReader.fromTopic(topic);
+    }
+
+    @Override
+    public <T extends GenericRecord> PTransform<
+        @NonNull PCollection<T>,
+        @NonNull PDone
+    > getWriter(final Class<T> clazz) {
+        if (topic == null) {
+            throw new IllegalStateException(
+                "Creating a Pubsub writer requires a GCP Topic, not a Subscription"
+            );
+        }
+
+        return PubsubIO.writeAvros(clazz).to(topic);
+    }
+}

--- a/lib/src/main/java/com/sanuscorp/transbeamer/TransBeamer.java
+++ b/lib/src/main/java/com/sanuscorp/transbeamer/TransBeamer.java
@@ -42,6 +42,24 @@ public final class TransBeamer {
     }
 
     /**
+     * Create a new TransBeamer {@link DataReader} that can ingest data of a
+     * given format into a given Avro class.
+     * @param format The {@link DataFormat} instance that describes the data
+     * format to read.
+     * @param clazz The Avro-generated class to populate with the data
+     * @return A {@link DataReader}
+     * {@link org.apache.beam.sdk.transforms.PTransform}that can read the given
+     * format.
+     * @param <T> The Avro-generated class type.
+     */
+    public static <T extends SpecificRecordBase> DataReader<T> newReader(
+        final DataFormat format,
+        final Class<T> clazz
+    ) {
+        return new DataReader<>(format, clazz);
+    }
+
+    /**
      * Create a new TransBeamer {@link FileWriter} that can produce data of a given
      * format at a given location from a given Avro class.
      * @param format The file format to write
@@ -57,5 +75,21 @@ public final class TransBeamer {
         final Class<T> clazz
     ) {
         return new FileWriter<>(format, location, clazz);
+    }
+
+    /**
+     * Create a new TransBeamer {@link DataWriter} that can take a
+     * {@link org.apache.beam.sdk.values.PCollection} backed by an
+     * Avro-generated class and write it to a given {@link DataFormat}.
+     * @param format The format to write to
+     * @param clazz The Avro-generated class of the collection to write.
+     * @return A {@link DataWriter} PTransform.
+     * @param <T> The specific type of Avro element that will be written out.
+     */
+    public static <T extends SpecificRecordBase> DataWriter<T> newWriter(
+        final DataFormat format,
+        final Class<T> clazz
+    ) {
+        return new DataWriter<>(format, clazz);
     }
 }

--- a/lib/src/test/java/com/sanuscorp/transbeamer/DataReaderTests.java
+++ b/lib/src/test/java/com/sanuscorp/transbeamer/DataReaderTests.java
@@ -1,0 +1,72 @@
+package com.sanuscorp.transbeamer;
+
+import com.sanuscorp.transbeamer.test.avro.Person;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link DataReader} class.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("The DataReader class")
+public class DataReaderTests {
+
+    @Nested
+    class when_expanded {
+
+        // Inputs
+        @Mock
+        private DataFormat format;
+
+        @Mock
+        private PBegin input;
+
+        // Interim Values
+        @Mock
+        private PTransform<
+            @NonNull PBegin,
+            @NonNull PCollection<Person>
+        > reader;
+
+        @Mock
+        private PCollection<Person> people;
+
+        private PCollection<Person> result;
+
+        @BeforeEach
+        void beforeEach() {
+            when(format.getReader(Person.class)).thenReturn(reader);
+            when(input.apply(anyString(), any())).thenReturn(people);
+            result = new DataReader<>(format, Person.class).expand(input);
+        }
+
+        @Test
+        void it_gets_the_expected_reader_from_the_format() {
+            verify(format).getReader(Person.class);
+        }
+
+        @Test
+        void it_applies_the_reader_to_the_input() {
+            verify(input).apply(anyString(), eq(reader));
+        }
+
+        @Test
+        void it_returns_the_expected_collection() {
+            assertThat(result).isEqualTo(people);
+        }
+    }
+}

--- a/lib/src/test/java/com/sanuscorp/transbeamer/DataWriterTests.java
+++ b/lib/src/test/java/com/sanuscorp/transbeamer/DataWriterTests.java
@@ -1,0 +1,73 @@
+package com.sanuscorp.transbeamer;
+
+import com.sanuscorp.transbeamer.test.avro.Person;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link DataWriter} class.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("The DataWriter class")
+public class DataWriterTests {
+
+    @Nested
+    class when_expanded {
+
+        // Inputs
+        @Mock
+        private DataFormat format;
+
+        @Mock
+        private PCollection<Person> input;
+
+        // Interim Values
+        @Mock
+        private PTransform<
+            @NonNull PCollection<Person>,
+            @NonNull PDone
+        > writer;
+
+        @Mock
+        private PDone pDone;
+
+        private PDone result;
+
+        @BeforeEach
+        void beforeEach() {
+            when(format.getWriter(Person.class)).thenReturn(writer);
+            when(input.apply(anyString(), any())).thenReturn(pDone);
+
+            result = new DataWriter<>(format, Person.class).expand(input);
+        }
+
+        @Test
+        void it_gets_the_expected_writer_from_the_format() {
+            verify(format).getWriter(Person.class);
+        }
+
+        @Test
+        void it_applies_the_writer_to_the_input() {
+            verify(input).apply(anyString(), eq(writer));
+        }
+
+        @Test
+        void it_returns_the_expected_collection() {
+            assertThat(result).isEqualTo(pDone);
+        }
+    }
+}

--- a/lib/src/test/java/com/sanuscorp/transbeamer/PubsubFormatTests.java
+++ b/lib/src/test/java/com/sanuscorp/transbeamer/PubsubFormatTests.java
@@ -1,0 +1,238 @@
+package com.sanuscorp.transbeamer;
+
+import com.sanuscorp.transbeamer.test.avro.Person;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link PubsubFormat} class.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("The PubsubFormat class")
+public class PubsubFormatTests {
+
+    // Fixtures
+    private static final String TOPIC = "/my/test/topic";
+
+    private static final String SUBSCRIPTION = "/my/test/subscription";
+
+    // Dependencies
+    @Mock
+    private MockedStatic<PubsubIO> mockedPubsubIO;
+
+    // Interim values
+    @Mock(answer = Answers.RETURNS_SELF)
+    private PubsubIO.Read<Person> avroReader;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private PubsubIO.Write<Person> avroWriter;
+
+    @Nested
+    class when_created_with_a_topic_and_getting_a_reader {
+
+        private PTransform<
+            @NonNull PBegin,
+            @NonNull PCollection<Person>
+        > result;
+
+        private PubsubFormat format;
+
+        @BeforeEach
+        void beforeEach() {
+            mockedPubsubIO.when(() -> PubsubIO.readAvros(Person.class))
+                .thenReturn(avroReader);
+
+            format = PubsubFormat.withTopic(TOPIC);
+            result = format.getReader(Person.class);
+        }
+        
+        @Test
+        void it_returns_the_expected_name() {
+            assertThat(format.getName())
+                .isEqualTo("GCP Pubsub Topic: " + TOPIC);
+        }
+
+        @Test
+        void it_creates_one_avro_reader() {
+            mockedPubsubIO.verify(() -> PubsubIO.readAvros(Person.class));
+        }
+
+        @Test
+        void it_creates_a_transform_from_the_topic() {
+            verify(avroReader).fromTopic(TOPIC);
+        }
+
+        @Test
+        void it_returns_the_expected_reader() {
+            assertThat(result).isEqualTo(avroReader);
+        }
+    }
+
+    @Nested
+    class when_created_with_a_topic_provider_and_getting_a_reader {
+
+        @Mock
+        private ValueProvider<String> topicProvider;
+
+        private PTransform<
+            @NonNull PBegin,
+            @NonNull PCollection<Person>
+        > result;
+
+        @BeforeEach
+        void beforeEach() {
+            when(topicProvider.get()).thenReturn(TOPIC);
+            mockedPubsubIO.when(() -> PubsubIO.readAvros(Person.class))
+                .thenReturn(avroReader);
+
+            result = PubsubFormat.withTopic(topicProvider).getReader(Person.class);
+        }
+
+        @Test
+        void it_creates_a_transform_from_the_topic() {
+            verify(avroReader).fromTopic(TOPIC);
+        }
+
+        @Test
+        void it_returns_the_expected_reader() {
+            assertThat(result).isEqualTo(avroReader);
+        }
+    }
+
+    @Nested
+    class when_created_with_a_subscription_and_getting_a_reader {
+
+        private PTransform<
+            @NonNull PBegin,
+            @NonNull PCollection<Person>
+        > result;
+
+        @BeforeEach
+        void beforeEach() {
+            mockedPubsubIO.when(() -> PubsubIO.readAvros(Person.class))
+                .thenReturn(avroReader);
+
+            result = PubsubFormat.withSubscription(SUBSCRIPTION).getReader(Person.class);
+        }
+
+        @Test
+        void it_creates_one_avro_reader() {
+            mockedPubsubIO.verify(() -> PubsubIO.readAvros(Person.class));
+        }
+
+        @Test
+        void it_creates_a_transform_from_the_subscription() {
+            verify(avroReader).fromSubscription(SUBSCRIPTION);
+        }
+
+        @Test
+        void it_returns_the_expected_reader() {
+            assertThat(result).isEqualTo(avroReader);
+        }
+    }
+
+    @Nested
+    class when_created_with_a_subscription_provider_and_getting_a_reader {
+        @Mock
+        private ValueProvider<String> subscriptionProvider;
+
+        private PTransform<
+            @NonNull PBegin,
+            @NonNull PCollection<Person>
+        > result;
+
+        @BeforeEach
+        void beforeEach() {
+            when(subscriptionProvider.get()).thenReturn(SUBSCRIPTION);
+            mockedPubsubIO.when(() -> PubsubIO.readAvros(Person.class))
+                .thenReturn(avroReader);
+
+            result = PubsubFormat.withSubscription(subscriptionProvider)
+                .getReader(Person.class);
+        }
+
+        @Test
+        void it_creates_a_transform_from_the_subscription() {
+            verify(avroReader).fromSubscription(SUBSCRIPTION);
+        }
+
+        @Test
+        void it_returns_the_expected_reader() {
+            assertThat(result).isEqualTo(avroReader);
+        }
+    }
+
+    @Nested
+    class when_created_with_a_topic_and_getting_a_writer {
+        private PTransform<
+            @NonNull PCollection<Person>,
+            @NonNull PDone
+        > result;
+
+        @BeforeEach
+        void beforeEach() {
+            mockedPubsubIO.when(() -> PubsubIO.writeAvros(Person.class))
+                .thenReturn(avroWriter);
+
+            result = PubsubFormat.withTopic(TOPIC).getWriter(Person.class);
+        }
+
+        @Test
+        void it_creates_one_avro_writer() {
+            mockedPubsubIO.verify(() -> PubsubIO.writeAvros(Person.class));
+        }
+
+        @Test
+        void it_creates_a_transform_from_the_topic() {
+            verify(avroWriter).to(TOPIC);
+        }
+
+        @Test
+        void it_returns_the_expected_writer() {
+            assertThat(result).isEqualTo(avroWriter);
+        }
+    }
+
+    @Nested
+    class when_created_with_a_subscription_and_getting_a_writer {
+        private Throwable thrown;
+
+        @BeforeEach
+        void beforeEach() {
+            final PubsubFormat format = PubsubFormat.withSubscription(
+                SUBSCRIPTION
+            );
+            thrown = catchThrowableOfType(
+                () -> format.getWriter(Person.class),
+                IllegalStateException.class
+            );
+        }
+
+        @Test
+        void it_throws_the_expected_exception() {
+            assertThat(thrown).hasMessage(
+                "Creating a Pubsub writer requires a GCP Topic, not a Subscription"
+            );
+        }
+    }
+
+}

--- a/lib/src/test/java/com/sanuscorp/transbeamer/TransBeamerTests.java
+++ b/lib/src/test/java/com/sanuscorp/transbeamer/TransBeamerTests.java
@@ -23,7 +23,11 @@ public class TransBeamerTests {
     // Fixtures
     private static final String LOCATION = "test/location";
 
-    private static final FileFormat FORMAT = CsvFormat.create();
+    private static final FileFormat FILE_FORMAT = CsvFormat.create();
+
+    private static final DataFormat DATA_FORMAT = PubsubFormat.withTopic(
+        "fake-topic"
+    );
 
     @Nested
     class when_getting_a_new_file_reader {
@@ -52,7 +56,7 @@ public class TransBeamerTests {
             );
 
             result = TransBeamer.newReader(
-                FORMAT,
+                FILE_FORMAT,
                 LOCATION,
                 Person.class
             );
@@ -71,7 +75,7 @@ public class TransBeamerTests {
         @Test
         void it_provides_the_expected_args_to_the_file_reader() {
             assertThat(fileReaderConstructionArgs).containsExactly(
-                FORMAT,
+                FILE_FORMAT,
                 LOCATION,
                 Person.class
             );
@@ -80,6 +84,61 @@ public class TransBeamerTests {
         @Test
         void it_returns_the_constructed_reader() {
             assertThat(result).isEqualTo(fileReader);
+        }
+    }
+
+    @Nested
+    class when_getting_a_new_data_reader {
+        // Dependencies
+        @SuppressWarnings("rawtypes")
+        private MockedConstruction<DataReader> mockedDataReaderConstruction;
+
+        // Interim values
+        @Mock
+        private DataReader<Person> dataReader;
+
+        private List<Object> dataReaderConstructionArgs;
+
+        private DataReader<Person> result;
+
+        @SuppressWarnings("unchecked")
+        @BeforeEach
+        void beforeEach() {
+            mockedDataReaderConstruction = mockConstruction(
+                DataReader.class,
+                (mock, context) -> {
+                    dataReaderConstructionArgs = new ArrayList<>(context.arguments());
+                    dataReader = mock;
+                }
+            );
+
+            result = TransBeamer.newReader(
+                DATA_FORMAT,
+                Person.class
+            );
+        }
+
+        @AfterEach
+        void afterEach() {
+            mockedDataReaderConstruction.close();
+        }
+
+        @Test
+        void it_creates_one_file_reader() {
+            assertThat(mockedDataReaderConstruction.constructed()).hasSize(1);
+        }
+
+        @Test
+        void it_provides_the_expected_args_to_the_file_reader() {
+            assertThat(dataReaderConstructionArgs).containsExactly(
+                DATA_FORMAT,
+                Person.class
+            );
+        }
+
+        @Test
+        void it_returns_the_constructed_reader() {
+            assertThat(result).isEqualTo(dataReader);
         }
     }
 
@@ -109,7 +168,7 @@ public class TransBeamerTests {
             );
 
             result = TransBeamer.newWriter(
-                FORMAT,
+                FILE_FORMAT,
                 LOCATION,
                 Person.class
             );
@@ -128,7 +187,7 @@ public class TransBeamerTests {
         @Test
         void it_provides_the_expected_args_to_the_file_writer() {
             assertThat(fileWriterConstructionArgs).containsExactly(
-                FORMAT,
+                FILE_FORMAT,
                 LOCATION,
                 Person.class
             );
@@ -140,4 +199,58 @@ public class TransBeamerTests {
         }
     }
 
+    @Nested
+    class when_getting_a_new_data_writer {
+        // Dependencies
+        @SuppressWarnings("rawtypes")
+        private MockedConstruction<DataWriter> mockedDataWriterConstruction;
+
+        // Interim values
+        @Mock
+        private DataWriter<Person> dataWriter;
+
+        private List<Object> dataWriterConstructionArgs;
+
+        private DataWriter<Person> result;
+
+        @SuppressWarnings("unchecked")
+        @BeforeEach
+        void beforeEach() {
+            mockedDataWriterConstruction = mockConstruction(
+                DataWriter.class,
+                (mock, context) -> {
+                    dataWriterConstructionArgs = new ArrayList<>(context.arguments());
+                    dataWriter = mock;
+                }
+            );
+
+            result = TransBeamer.newWriter(
+                DATA_FORMAT,
+                Person.class
+            );
+        }
+
+        @AfterEach
+        void afterEach() {
+            mockedDataWriterConstruction.close();
+        }
+
+        @Test
+        void it_creates_one_file_writer() {
+            assertThat(mockedDataWriterConstruction.constructed()).hasSize(1);
+        }
+
+        @Test
+        void it_provides_the_expected_args_to_the_file_writer() {
+            assertThat(dataWriterConstructionArgs).containsExactly(
+                DATA_FORMAT,
+                Person.class
+            );
+        }
+
+        @Test
+        void it_returns_the_constructed_writer() {
+            assertThat(result).isEqualTo(dataWriter);
+        }
+    }
 }

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -40,3 +40,13 @@ createSampleTask(
     'convertCsvToAvroAndParquet',
     'com.sanuscorp.transbeamer.samples.ConvertCsvToAvroAndParquet'
 )
+
+createSampleTask(
+    'publishCsvToPubsub',
+    'com.sanuscorp.transbeamer.samples.PublishCsvToPubsub'
+)
+
+createSampleTask(
+    'logFromPubsub',
+    'com.sanuscorp.transbeamer.samples.LogFromPubsub'
+)

--- a/samples/src/main/java/com/sanuscorp/transbeamer/samples/LogFromPubsub.java
+++ b/samples/src/main/java/com/sanuscorp/transbeamer/samples/LogFromPubsub.java
@@ -1,0 +1,42 @@
+package com.sanuscorp.transbeamer.samples;
+
+import com.sanuscorp.transbeamer.PubsubFormat;
+import com.sanuscorp.transbeamer.TransBeamer;
+import com.sanuscorp.transbeamer.samples.avro.StarWarsMovie;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+
+public class LogFromPubsub {
+
+    public static void main(String[] args) {
+        final String topicName = System.getenv("TOPIC_NAME");
+        if (topicName == null) {
+            throw new RuntimeException("TOPIC_NAME environment variable must be set");
+        }
+
+        Pipeline pipeline = Pipeline.create();
+
+        System.out.println("Listening for messages on topic: \n\t" + topicName);
+
+        pipeline.apply(
+            TransBeamer.newReader(
+                PubsubFormat.withTopic(topicName),
+                StarWarsMovie.class
+            )
+        ).apply(
+            ParDo.of(new DoFn<StarWarsMovie, Void>() {
+                @ProcessElement
+                public void processElement(@Element StarWarsMovie movie) {
+                    System.out.println(
+                        "Read StarWarsMovie from Pubsub: " + movie.toString()
+                    );
+                }
+            })
+        );
+
+        System.out.println("\nCTRL-C to stop\n");
+
+        pipeline.run().waitUntilFinish();
+    }
+}

--- a/samples/src/main/java/com/sanuscorp/transbeamer/samples/PublishCsvToPubsub.java
+++ b/samples/src/main/java/com/sanuscorp/transbeamer/samples/PublishCsvToPubsub.java
@@ -1,0 +1,35 @@
+package com.sanuscorp.transbeamer.samples;
+
+import com.sanuscorp.transbeamer.CsvFormat;
+import com.sanuscorp.transbeamer.PubsubFormat;
+import com.sanuscorp.transbeamer.TransBeamer;
+import com.sanuscorp.transbeamer.samples.avro.StarWarsMovie;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.values.PCollection;
+
+public class PublishCsvToPubsub {
+
+    public static void main(String[] args) {
+        final String topicName = System.getenv("TOPIC_NAME");
+        if (topicName == null) {
+            throw new RuntimeException("TOPIC_NAME environment variable must be set");
+        }
+
+        Pipeline pipeline = Pipeline.create();
+        final PCollection<StarWarsMovie> movies = pipeline.apply(
+            TransBeamer.newReader(
+                CsvFormat.create(), "input", StarWarsMovie.class
+            )
+        );
+
+        movies.apply(
+            TransBeamer.newWriter(
+                PubsubFormat.withTopic(topicName), StarWarsMovie.class
+            )
+        );
+
+        System.out.println("\nWriting StarWarsMovies to Pubsub: " + topicName + "\n\t");
+        pipeline.run().waitUntilFinish();
+        System.out.println("Done!");
+    }
+}

--- a/samples/src/main/java/com/sanuscorp/transbeamer/samples/Welcome.java
+++ b/samples/src/main/java/com/sanuscorp/transbeamer/samples/Welcome.java
@@ -10,34 +10,46 @@ public class Welcome {
      */
     public static void main(String[] args) {
         System.out.println("""
-        Welcome! \s
+Welcome!
         
-        The TransBeamer library provides utilities for\s
-        reading and writing data in various formats,\s
-        populating Avro-based PCollections as interim values.\s
+The TransBeamer library provides utilities for reading and writing data in
+various formats, populating Avro-based PCollections as interim values.
         
-        This currently supports the following formats:\s
-          - Avro\s
-          - Parquet\s
-          - CSV\s
-          - ND-JSON\s
+This currently supports the following formats:
+  - Avro
+  - Parquet
+  - CSV
+  - ND-JSON
+  - GCP Pubsub
         
-        The "samples" project provides apps that produce different\s
-        file formats in the "samples/build" directory.\s
+The "samples" project provides apps that produce different file formats in a
+variety of ways.
         """);
 
         System.out.println("""
         
-        For Instance:
-        -----------------------------------------------------
-        See code that reads CSV, then writes out Parquet & Avro here:
+For Instance:
+-------------------------------------------------------------
+See code that reads CSV, then writes out Parquet & Avro here:
         
-          samples/src/main/java/.../ConvertCsvToAvroAndParquet.java\s
+  samples/src/main/java/.../ConvertCsvToAvroAndParquet.java
         
-        To run that sample, run this Gradle task:
+To run that sample, run this Gradle task:
         
-          ./gradlew convertCsvToAvroAndParquet
+  ./gradlew convertCsvToAvroAndParquet
+-------------------------------------------------------------
+See code that reads CSV, then writes to a Pubsub topic, as well as code that
+reads from a Pubsub topic and logs messages, see here:
+ 
+  samples/src/main/java/.../PublishCsvToPubsub.java
+  samples/src/main/java/.../LogFromPubsub.java
         
-        """);
+To run those samples, set the TOPIC_NAME environment variable to the topic you
+want to publish/read from, then run these tasks in different terminals:
+  
+  TOPIC_NAME=/projects/myproject-id/topics/mytopic-name ./gradlew logFromPubsub
+  TOPIC_NAME=/projects/myproject-id/topics/mytopic-name ./gradlew publishCsvToPubsub
+-------------------------------------------------------------
+""");
     }
 }


### PR DESCRIPTION
This change overloads the high-level API so that the formats we provide
can either be FileIO-based _or_ generic data-based formats.  The first
data-based format to support is GCP Pubsub, which was unsuprisingly
simple to implement.  The hope is we can follow this up with future
data-based formats, like Iceberg.
